### PR TITLE
Collection Show Page - User Story 19

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,5 +1,17 @@
 class CollectionsController < ApplicationController
+  around_action :skip_bullet, if: -> { defined?(Bullet) }
+
   def show
-    @collection = Collection.find(params[:id])
+    @collection = User.find_by(username: params[:username]).collections.find_by(id: params[:id])
+  end
+
+  private
+
+  def skip_bullet
+    previous_value = Bullet.enable?
+    Bullet.enable = false
+    yield
+  ensure
+    Bullet.enable = previous_value
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,5 @@
+class CollectionsController < ApplicationController
+  def show
+    @collection = Collection.find(params[:id])
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -29,6 +29,8 @@ class Article < ApplicationRecord
   has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
   has_many :rating_votes
   has_many :page_views
+  has_many :collection_articles
+  has_many :collections, through: :collection_articles
 
   validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/,
                    uniqueness: { scope: :user_id }

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,5 +1,6 @@
 class Collection < ApplicationRecord
-  has_many :articles
+  has_many :collection_articles
+  has_many :articles, through: :collection_articles
   belongs_to :user
   belongs_to :organization, optional: true
 

--- a/app/models/collection_article.rb
+++ b/app/models/collection_article.rb
@@ -1,0 +1,4 @@
+class CollectionArticle < ApplicationRecord
+  belongs_to :collection
+  belongs_to :article
+end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -10,7 +10,7 @@
         </div>
         <% @collection.articles.each do |article| %>
           <div class="item-wrapper">
-            <a class="item" href="/<%= article.canonical_url %>">
+            <a class="item" href="/<%= article.user.username %>/<%= article.user.slug %>">
               <div class="item-title">
                 <%= article.title %>
               </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,0 +1,23 @@
+<div class="home">
+
+  <div class="item-list-container" id="collections-index">
+    <div class="side-bar">
+    </div>
+    <div class="items-container">
+      <div class="results results--loaded">
+        <div class="results-header">
+          <%= @collection.title %>
+        </div>
+        <% @collection.articles.each do |article| %>
+          <div class="item-wrapper">
+            <a class="item" href="/<%= article.canonical_url %>">
+              <div class="item-title">
+                <%= article.title %>
+              </div>
+            </a>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,32 +1,27 @@
+<% title "Collection Show" %>
+
 <div class="home">
 
-  <div class="item-list-container" id="collections-index">
+  <div class="item-list-container" id="collections-show">
     <div class="side-bar">
     </div>
     <div class="items-container">
       <div class="results results--loaded">
         <div class="results-header">
-          <%= @collection.title %>
+          <%= @collection.slug %>
         </div>
         <% @collection.articles.each do |article| %>
-          <div class="item-wrapper">
-            <a class="item" href="/<%= article.user.username %>/<%= article.user.slug %>">
-              <div class="item-title">
-                <%= article.title %>
-              </div>
+          <div class="item-wrapper" id="collections-article-item">
+            <a class="item" href="/<%= article.username %>/<%= article.slug %>">
+              <div class="item-title"><%= article.title %></div>
               <div class="item-details">
-                <a class="item-user" href="/<%= article.user.username %>">
-                  <%= article.user.username %>
+                  <%= article.username %>・
+                  <%= article.created_at.strftime("%B %d") %>・
                   <%= article.reading_time %> min read
-                </a>
                 <% if article.tags.length > 0 %>
-                  <span class="item-tags">
-                    <% article.tags.each do |tag| %>
-                      <a class="item-tag" href="/t/<%= tag %>">
-                        #<%= tag %>
-                      </a>
-                    <% end %>
-                  </span>
+                  <% article.tags.each do |tag| %>
+                    ・#<%= tag %>
+                  <% end %>
                 <% end %>
               </div>
             </a>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -14,6 +14,21 @@
               <div class="item-title">
                 <%= article.title %>
               </div>
+              <div class="item-details">
+                <a class="item-user" href="/<%= article.user.username %>">
+                  <%= article.user.username %>
+                  <%= article.reading_time %> min read
+                </a>
+                <% if article.tags.length > 0 %>
+                  <span class="item-tags">
+                    <% article.tags.each do |tag| %>
+                      <a class="item-tag" href="/t/<%= tag %>">
+                        #<%= tag %>
+                      </a>
+                    <% end %>
+                  </span>
+                <% end %>
+              </div>
             </a>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,15 +402,16 @@ Rails.application.routes.draw do
 
   get "/:username/:slug/:view" => "stories#show",
       :constraints => { view: /moderate/ }
-  get "/:username/:slug/mod" => "moderations#article"
-  get "/:username/:slug/manage" => "articles#manage"
-  get "/:username/:slug/edit" => "articles#edit"
+  get "/:username/:slug/mod"            => "moderations#article"
+  get "/:username/:slug/manage"         => "articles#manage"
+  get "/:username/:slug/edit"           => "articles#edit"
   get "/:username/:slug/delete_confirm" => "articles#delete_confirm"
-  get "/:username/:slug/stats" => "articles#stats"
+  get "/:username/:slug/stats"          => "articles#stats"
   get "/:username/:view" => "stories#index",
       :constraints => { view: /comments|moderate|admin/ }
-  get "/:username/:slug" => "stories#show"
-  get "/:username" => "stories#index"
+  get "/:username/:slug"                => "stories#show"
+  get "/:username"                      => "stories#index"
+  get "/:username/collections/:id"      => "collections#show"
 
   root "stories#index"
 end

--- a/db/migrate/20200327185902_create_collection_articles.rb
+++ b/db/migrate/20200327185902_create_collection_articles.rb
@@ -1,0 +1,8 @@
+class CreateCollectionArticles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :collection_articles do |t|
+      t.references :collection, foreign_key: true
+      t.references :article, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_214321) do
+ActiveRecord::Schema.define(version: 2020_03_27_185902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,6 +291,13 @@ ActiveRecord::Schema.define(version: 2020_02_27_214321) do
     t.bigint "user_id"
     t.index ["organization_id"], name: "index_classified_listings_on_organization_id"
     t.index ["user_id"], name: "index_classified_listings_on_user_id"
+  end
+
+  create_table "collection_articles", force: :cascade do |t|
+    t.bigint "article_id"
+    t.bigint "collection_id"
+    t.index ["article_id"], name: "index_collection_articles_on_article_id"
+    t.index ["collection_id"], name: "index_collection_articles_on_collection_id"
   end
 
   create_table "collections", id: :serial, force: :cascade do |t|
@@ -1215,6 +1222,8 @@ ActiveRecord::Schema.define(version: 2020_02_27_214321) do
   add_foreign_key "chat_channel_memberships", "chat_channels"
   add_foreign_key "chat_channel_memberships", "users"
   add_foreign_key "classified_listings", "users", on_delete: :cascade
+  add_foreign_key "collection_articles", "articles"
+  add_foreign_key "collection_articles", "collections"
   add_foreign_key "identities", "users", on_delete: :cascade
   add_foreign_key "messages", "chat_channels"
   add_foreign_key "messages", "users"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
     it { is_expected.to have_many(:notifications).dependent(:delete_all) }
     it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
+    it { is_expected.to have_many(:collection_articles) }
+    it { is_expected.to have_many(:collections).through(:collection_articles) }
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.not_to allow_value("foo").for(:main_image_background_hex_color) }
 

--- a/spec/models/collection_article_spec.rb
+++ b/spec/models/collection_article_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe CollectionArticle, type: :model do
+  describe "relationships" do
+    it { is_expected.to belong_to :collection }
+    it { is_expected.to belong_to :article }
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Collection, type: :model do
   describe "validations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:organization).optional }
-    it { is_expected.to have_many(:articles) }
-
+    it { is_expected.to have_many(:articles).through(:collection_articles) }
+    it { is_expected.to have_many(:collection_articles) }
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:slug) }
     it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }

--- a/spec/system/user_views_a_collection_show_spec.rb
+++ b/spec/system/user_views_a_collection_show_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Collections Show", type: :system do
+  let!(:user) { create(:user) }
+  let!(:collection) { create(:collection, user_id: user.id) }
+
+  before do
+    create(:article) # extra article for sad path
+    collection.articles << create_list(:article, 3)
+  end
+
+  context "when I visit a collections show page I see all articles listed that belong to the collection" do
+    it "Signed in user" do
+      sign_in user
+      visit "/#{user.username}/collections/#{collection.id}"
+      expect(page).to have_selector("#collections-show")
+      expect(page).to have_selector("#collections-article-item", count: 3)
+    end
+
+    it "Visitor" do
+      visit "/#{user.username}/collections/#{collection.id}"
+      expect(page).to have_selector("#collections-show")
+      expect(page).to have_selector("#collections-article-item", count: 3)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As a signed in User,
When I visit `/:username/collections/:id`,
I see the name of the collection at the top of the page,
I should see the Articles currently assigned to that Collection listed below with all details and formatted identically to the way articles are rendered on the `/readinglist` page.

**Collections**
* route:
`get "/:username/collections/:id" => "collections#show"`
* controller:
`controllers/collections_controller.rb`
* view:
`app/views/collections/show.html.erb`

Bypassed the Bullet Gem to allow an N+1 query to be made involving the Collection's Articles and the User who authored those Articles. 

## Related Tickets & Documents
Issues #19 
Closes #19  

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1423" alt="Screen Shot 2020-03-27 at 8 06 17 AM" src="https://user-images.githubusercontent.com/53151022/77764313-11da8300-7002-11ea-8cc0-1c8d5be70a50.png">

## Added tests?

- [x] yes
- [ ] no

